### PR TITLE
Update runtime to 3.38

### DIFF
--- a/org.freedesktop.Piper.json
+++ b/org.freedesktop.Piper.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.freedesktop.Piper",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.34",
+    "runtime-version": "3.38",
     "sdk": "org.gnome.Sdk",
     "command": "piper",
       "finish-args": [

--- a/org.freedesktop.Piper.json
+++ b/org.freedesktop.Piper.json
@@ -39,8 +39,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://files.pythonhosted.org/packages/39/2b/0a66d5436f237aff76b91e68b4d8c041d145ad0a2cdeefe2c42f76ba2857/lxml-4.5.0.tar.gz",
-                    "sha256": "8620ce80f50d023d414183bf90cc2576c2837b88e00bea3f33ad2630133bbb60"
+                    "url": "https://files.pythonhosted.org/packages/2c/4d/3ec1ea8512a7fbf57f02dee3035e2cce2d63d0e9c0ab8e4e376e01452597/lxml-4.5.2.tar.gz",
+                    "sha256": "cdc13a1682b2a6241080745b1953719e7fe0850b40a5c71ca574f090a1391df6"
                 }
             ]
         },


### PR DESCRIPTION
This MR updates the GNOME runtime to 3.38, and lxml to its latest point release.

Replaces #9.