### PR TITLE
chore(update): org.gnome.Platform 41 & more

### DIFF
--- a/org.freedesktop.Piper.json
+++ b/org.freedesktop.Piper.json
@@ -8,7 +8,8 @@
         "--share=ipc",
         "--socket=x11",
         "--socket=wayland",
-        "--system-talk-name=org.freedesktop.ratbag1"
+        "--system-talk-name=org.freedesktop.ratbag1",
+        "--device=dri"
       ],
     "modules": [
         {

--- a/org.freedesktop.Piper.json
+++ b/org.freedesktop.Piper.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.freedesktop.Piper",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "command": "piper",
       "finish-args": [

--- a/org.freedesktop.Piper.json
+++ b/org.freedesktop.Piper.json
@@ -20,27 +20,35 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://files.pythonhosted.org/packages/89/83/5f5635fd0d91a08ac355dd9ca9bde34bfa6b29a5c59f703ad83d1ad0bf34/evdev-1.3.0.tar.gz",
-                    "sha256": "b1c649b4fed7252711011da235782b2c260b32e004058d62473471e5cd30634d"
+                    "url": "https://files.pythonhosted.org/packages/89/83/5f5635fd0d91a08ac355dd9ca9bde34bfa6b29a5c59f703ad83d1ad0bf34/evdev-1.4.0.tar.gz",
+                    "sha256": "8782740eb1a86b187334c07feb5127d3faa0b236e113206dfe3ae8f77fb1aaf1"
                 }
             ]
         },
         {
             "name": "python-lxml",
             "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --prefix=/app --no-deps ."
+            "ensure-writable": [
+                "/app/lib/python*/site-packages/easy-install.pth",
+                "/app/lib/python*/site-packages/setuptools.pth",
+                "/lib/python*/site-packages/easy-install.pth",
+                "/lib/python*/site-packages/setuptools.pth"
             ],
-            "build-options": {
-                "env": {
-                    "XSLT_CONFIG": "pkg-config libxslt"
-                }
-            },
+            "build-commands": [
+                "python3 setup.py build --with-cython",
+                "python3 setup.py install --prefix=/app --root=/"
+            ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://files.pythonhosted.org/packages/2c/4d/3ec1ea8512a7fbf57f02dee3035e2cce2d63d0e9c0ab8e4e376e01452597/lxml-4.5.2.tar.gz",
-                    "sha256": "cdc13a1682b2a6241080745b1953719e7fe0850b40a5c71ca574f090a1391df6"
+                    "type": "git",
+                    "url": "https://github.com/lxml/lxml.git",
+                    "tag": "lxml-4.6.3"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "sed -i 's/if not platform_/if not dirs/' setup.py"
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
Basically maintenance update. GNOME runtime 3.38 already EOL, so we must switch to new one version. Also updated few modules and added new permission.

Tested with my Logitech mouse and LGTM so far.

EDIT: rationale for changing `python-lxml` module build - https://gitlab.gnome.org/GNOME/gnome-build-meta/-/issues/380.

Close #12 