### PR TITLE
Add xdg-config permission to fix dark theme

### DIFF
--- a/org.freedesktop.Piper.json
+++ b/org.freedesktop.Piper.json
@@ -9,7 +9,8 @@
         "--socket=x11",
         "--socket=wayland",
         "--system-talk-name=org.freedesktop.ratbag1",
-        "--device=dri"
+        "--device=dri",
+        "--filesystem=xdg-config/gtk-3.0:ro"
       ],
     "modules": [
         {


### PR DESCRIPTION
I noticed that by default this app is not themed correctly on my system. This additional permission should resolve the broken theming on some systems.

Tested on my system:
Theme: Breeze Dark (org.gtk.Gtk3theme.Breeze)
Operating System: Arch Linux
KDE Plasma Version: 5.27.7
KDE Frameworks Version: 5.108.0
Qt Version: 5.15.10
Kernel Version: 6.4.9-arch1-1 (64-bit)
Graphics Platform: Wayland