### PR TITLE
Update org.gnome.Platform to v44

### DIFF
--- a/org.freedesktop.Piper.json
+++ b/org.freedesktop.Piper.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.freedesktop.Piper",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
     "command": "piper",
       "finish-args": [


### PR DESCRIPTION
Update the platform to v44 since the GNOME 43 runtime is no longer supported as of September 20, 2023. Tested locally and everything works as expected.